### PR TITLE
reset timer shouldn't set active to false

### DIFF
--- a/src/tooltip.directive.ts
+++ b/src/tooltip.directive.ts
@@ -229,7 +229,6 @@ export class Tooltip implements AfterViewInit {
   }
 
   private _resetTimer() {
-    this.active = false;
     clearTimeout(this.tooltipTimeout);
     this.tooltipTimeout = setTimeout(this._removeTooltip.bind(this), this.duration);
   }


### PR DESCRIPTION
By setting the timer to false, you immediately close the tooltip rather than resetting the timer and closing it at the end of the timer duration.